### PR TITLE
Finish create account page polish

### DIFF
--- a/frontend/src/components/CreateAccount.css
+++ b/frontend/src/components/CreateAccount.css
@@ -78,6 +78,8 @@
   font-size: 15px;
   background: white;
   transition: border-color 0.2s, box-shadow 0.2s;
+  color: #111827;
+  caret-color: #111827;
 }
 
 .form-input:focus {
@@ -88,6 +90,7 @@
 
 .form-input::placeholder {
   color: #9ca3af;
+  opacity: 1;
 }
 
 .btn-primary {

--- a/frontend/src/components/CreateAccount.jsx
+++ b/frontend/src/components/CreateAccount.jsx
@@ -8,19 +8,17 @@ const CreateAccount = () => {
     <div className="create-account-container">
       <div className="create-account-card">
         <div className="logo-box">
-          <div className="logo-circle">
-            🤝
-          </div>
+          <div className="logo-circle">🤝</div>
         </div>
 
         <h2 className="title">Create Account</h2>
-        <p className="subtitle">
-          Join your community and start helping
-        </p>
+        <p className="subtitle">Join your community and start helping</p>
 
-        <div className="form-group">
-          <label className="form-label">Full name</label>
+       <div className="form-group">
+          <label className="form-label" htmlFor="fullName">Full name</label>
           <input
+            id="fullName"
+            name="fullName"
             type="text"
             placeholder="Enter your full name"
             className="form-input"
@@ -28,8 +26,10 @@ const CreateAccount = () => {
         </div>
 
         <div className="form-group">
-          <label className="form-label">Email address</label>
+          <label className="form-label" htmlFor="email">Email address</label>
           <input
+            id="email"
+            name="email"
             type="email"
             placeholder="Enter your email"
             className="form-input"
@@ -37,8 +37,10 @@ const CreateAccount = () => {
         </div>
 
         <div className="form-group">
-          <label className="form-label">Password</label>
+          <label className="form-label" htmlFor="password">Password</label>
           <input
+            id="password"
+            name="password"
             type="password"
             placeholder="Create a password"
             className="form-input"
@@ -46,23 +48,27 @@ const CreateAccount = () => {
         </div>
 
         <div className="form-group">
-          <label className="form-label">Confirm password</label>
+          <label className="form-label" htmlFor="confirmPassword">Confirm password</label>
           <input
+            id="confirmPassword"
+            name="confirmPassword"
             type="password"
             placeholder="Confirm your password"
             className="form-input"
           />
         </div>
 
-        <button 
+        <button
           className="btn-primary"
-          onClick={() => navigate("/community-aid")}
+          type="button"
+          onClick={() => navigate("/dashboard")}
         >
           Create Account
         </button>
 
         <button
           className="btn-secondary"
+          type="button"
           onClick={() => navigate("/")}
         >
           Already have an account? Sign In

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 import './Login.css';
 import communityImg from '../assets/community-aid-bg.jpg';
 import logo from '../assets/logo.png';
+import { useNavigate } from "react-router-dom";
 
 export default function Login() {
+  const navigate = useNavigate();
   return (
     <div className="login-page">
       <div className="login-container">
@@ -28,7 +30,7 @@ export default function Login() {
               <input type="password" placeholder="Password" className="login-input" />
               
               <button type="submit" className="btn-sign-in">Sign In</button>
-              <button type="button" className="btn-create-account">Create an account</button>
+              <button type="button" className="btn-create-account" onClick={() => navigate("/create-account")}>Create an account</button>
             </form>
           </div>
         </div>


### PR DESCRIPTION
Closes #6

Finishes the remaining Create Account page review nitpicks from PR #27:

- adds id and name attributes to form inputs

- keeps the existing routes intact

- keeps the secondary button clearly as navigation back to sign in

- fixes input text visibility in the Create Account form

- wires Create Account flow to continue into the app

This PR is intended to supersede PR #27.